### PR TITLE
fix: arrow vs regular function examples are the same

### DIFF
--- a/posts/arrow-vs-regular-function.md
+++ b/posts/arrow-vs-regular-function.md
@@ -136,7 +136,7 @@ Looking at the two versions below, it is easy for the first variant to cause a m
 
 ```js
 // Bad
-const compareToZero = (a) => (a <= 0 ? 0 : a);
+const compareToZero = (a) => a <= 0 ? 0 : a;
 
 // Good
 const compareToZero = (a) => (a <= 0 ? 0 : a);


### PR DESCRIPTION
Hi.
The good and bad examples in the `arrow vs regular function` are the same. So I made a change to correct the examples.