### PR TITLE
Update encode-uri-vs-encode-uri-component.md

### DIFF
--- a/posts/encode-uri-vs-encode-uri-component.md
+++ b/posts/encode-uri-vs-encode-uri-component.md
@@ -63,15 +63,15 @@ Because a URL can consist of standard ASCII characters only, other special chara
     ```js
     const encode = (str) =>
         encodeURIComponent(str)
-            .replace(/\\-/g, '%2D')
-            .replace(/\\_/g, '%5F')
-            .replace(/\\./g, '%2E')
-            .replace(/\\!/g, '%21')
-            .replace(/\\~/g, '%7E')
-            .replace(/\\*/g, '%2A')
-            .replace(/\\'/g, '%27')
-            .replace(/\\(/g, '%28')
-            .replace(/\\)/g, '%29');
+            .replace(/\-/g, '%2D')
+            .replace(/\_/g, '%5F')
+            .replace(/\./g, '%2E')
+            .replace(/\!/g, '%21')
+            .replace(/\~/g, '%7E')
+            .replace(/\*/g, '%2A')
+            .replace(/\'/g, '%27')
+            .replace(/\(/g, '%28')
+            .replace(/\)/g, '%29');
 
     encode("What's result of (4 + 2)?"); // "What%27s%20result%20of%20%284%20%2B%202%29%3F"
     ```


### PR DESCRIPTION
repeated `\`。

```js
const encode = (str) =>
        encodeURIComponent(str)
            .replace(/\\-/g, '%2D')
            .replace(/\\_/g, '%5F')
            .replace(/\\./g, '%2E')
            .replace(/\\!/g, '%21')
            .replace(/\\~/g, '%7E')
            .replace(/\\*/g, '%2A')
            .replace(/\\'/g, '%27')
            .replace(/\\(/g, '%28')
            .replace(/\\)/g, '%29');
console.log(encode('-');
```

<img width="742" alt="image" src="https://user-images.githubusercontent.com/30540533/174116946-56c6e438-ee11-4908-879a-ebcb8ff7abd0.png">

After fix:

```js
const encode = (str) =>
        encodeURIComponent(str)
            .replace(/\-/g, '%2D')
            .replace(/\_/g, '%5F')
            .replace(/\./g, '%2E')
            .replace(/\!/g, '%21')
            .replace(/\~/g, '%7E')
            .replace(/\*/g, '%2A')
            .replace(/\'/g, '%27')
            .replace(/\(/g, '%28')
            .replace(/\)/g, '%29');
console.log(encode('-'));
```
<img width="742" alt="image" src="https://user-images.githubusercontent.com/30540533/174117209-e95fb1ca-947d-4a55-95c7-6b4eb240f9ba.png">

